### PR TITLE
Nuevo deviceClass

### DIFF
--- a/resources/lib/movistar.py
+++ b/resources/lib/movistar.py
@@ -40,7 +40,7 @@ class Movistar(object):
     #dplayer = 'webplayer'
     #device_code = 'WP_OTT'
     #manufacturer = 'Firefox'
-    dplayer = 'android.tv'
+    dplayer = 'amazon.tv'
     device_code = 'SMARTTV_OTT'
     manufacturer = 'LG'
     account_dir = 'account_1'


### PR DESCRIPTION
El dispositivo "android.tv" está siendo bloqueado en la API de initData. Se cambia por "amazon.tv" que aún no está bloqueado.